### PR TITLE
update support for manage additional class/jar in resource directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ Plugin based on the [IntelliJ Platform Plugin Template][template].
 
 - [ ] you need to disable kotlin plugin if using old version of gradle, due to issue: https://stackoverflow.com/questions/70448459/gradle-error-in-ijresolvers-gradle-when-running-using-intellij-idea/70597547#70597547
 - [ ] it cannot find the classpath if the project is not managed by Gradle, click on the Project structure and import the project as Gradle project
+- [ ] it cannot find the resource directory if you don't mark the directory as resource root, right click on the directory and mark as resource root

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ junit = "4.13.2"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.0.1"
+intelliJPlatform = "2.1.0"
 kotlin = "1.9.25"
 kover = "0.8.3"
 qodana = "2024.1.9"

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/actions/RunPitestAction.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/actions/RunPitestAction.kt
@@ -1,27 +1,14 @@
 package com.github.jaksonlin.pitestintellij.actions
-import PrepareEnvironmentCommand
+import com.github.jaksonlin.pitestintellij.commands.PrepareEnvironmentCommand
 import com.github.jaksonlin.pitestintellij.commands.BuildPitestCommandCommand
 import com.github.jaksonlin.pitestintellij.commands.HandlePitestResultCommand
 import com.github.jaksonlin.pitestintellij.commands.PitestContext
 import com.github.jaksonlin.pitestintellij.commands.RunPitestCommand
-import com.github.jaksonlin.pitestintellij.ui.PitestOutputDialog
-import com.github.jaksonlin.pitestintellij.util.*
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.PathManager
-import com.intellij.openapi.diagnostic.thisLogger
-import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
-import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.openapi.ui.Messages
-import java.awt.Desktop
-import java.io.File
-import java.net.URI
-import java.nio.file.Paths
 
 class RunPitestAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/BuildPitestCommandCommand.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/BuildPitestCommandCommand.kt
@@ -9,7 +9,7 @@ class BuildPitestCommandCommand (project: Project, context: PitestContext) : Pit
         val reportDirectory = context.reportDirectory ?: throw IllegalStateException("Report directory not set")
         val classpathFile = context.classpathFile ?: throw IllegalStateException("Classpath file not set")
         val fullyQualifiedTargetTestClassName = context.fullyQualifiedTargetTestClassName ?: throw IllegalStateException("Fully qualified target class name not set")
-        val fullyQualifiedTargetClassName = context.fullyQualifiedTargetClassName ?: throw IllegalStateException("Fully qualified target class name not set")
+        val fullyQualifiedTargetClassName = context.targetClassFullyQualifiedName ?: throw IllegalStateException("Fully qualified target class name not set")
         val targetClassSourceRoot = context.targetClassSourceRoot ?: throw IllegalStateException("target class source root not set")
         val javaHome = context.javaHome ?: throw IllegalStateException("Java home not set")
         val javaExe = "$javaHome/bin/java"

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/PitestContext.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/PitestContext.kt
@@ -16,6 +16,7 @@ data class PitestContext(
     var command: List<String> = emptyList(),
     var processResult: ProcessResult? = null,
     var pitestDependencies: String? = null,
+    var resourceDirectories: List<String>? = null
 )
 
 fun dumpPitestContext(context: PitestContext): String {

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/PitestContext.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/PitestContext.kt
@@ -9,10 +9,12 @@ data class PitestContext(
     var fullyQualifiedTargetTestClassName: String? = null,
     var javaHome: String? = null,
     var sourceRoots: List<Path> = emptyList(),
-    var fullyQualifiedTargetClassName: String? = null,
+    var targetClassFullyQualifiedName: String? = null,
+    var targetClassPackageName: String? = null,
     var targetClassSourceRoot:String?=null,
     var reportDirectory: String? = null,
     var classpathFile: String? = null,
+    var classpathFileDirectory: String? = null,
     var command: List<String> = emptyList(),
     var processResult: ProcessResult? = null,
     var pitestDependencies: String? = null,
@@ -25,7 +27,7 @@ fun dumpPitestContext(context: PitestContext): String {
         fullyQualifiedTargetTestClassName: ${context.fullyQualifiedTargetTestClassName}
         javaHome: ${context.javaHome}
         sourceRoots: ${context.sourceRoots}
-        fullyQualifiedTargetClassName: ${context.fullyQualifiedTargetClassName}
+        fullyQualifiedTargetClassName: ${context.targetClassFullyQualifiedName}
         targetClassSourceRoot: ${context.targetClassSourceRoot}
         reportDirectory: ${context.reportDirectory}
         classpathFile: ${context.classpathFile}

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/PrepareEnvironmentCommand.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/PrepareEnvironmentCommand.kt
@@ -1,11 +1,11 @@
-import com.github.jaksonlin.pitestintellij.commands.PitestContext
+package com.github.jaksonlin.pitestintellij.commands
+
+import PitestCommand
 import com.github.jaksonlin.pitestintellij.util.FileUtils
 import com.github.jaksonlin.pitestintellij.util.GradleUtils
 import com.github.jaksonlin.pitestintellij.util.JavaFileProcessor
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.application.ReadAction
-import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
@@ -34,20 +34,23 @@ class PrepareEnvironmentCommand(project: Project, context: PitestContext) : Pite
         collectSourceRoots()
         collectResourceDirectories()
         
-        collectTargetClassThatWeTest()
-        prepareReportDirectory()
-        setupPitestLibDependencies()
-        collectClassPathFileForPitest()
+        collectTargetClassThatWeTest(context.sourceRoots)
+        prepareReportDirectory(testVirtualFile)
+
+        setupPitestLibDependencies(context.resourceDirectories!!)
+        collectClassPathFileForPitest(context.reportDirectory!!, context.targetClassPackageName!!, context.resourceDirectories)
     }
 
-    private fun collectTargetTestClassName(targetTestCalssFilePath:String) {
+    private fun collectTargetTestClassName(targetTestClassFilePath:String) {
 
-        context.fullyQualifiedTargetTestClassName = javaFileProcessor.getFullyQualifiedName(targetTestCalssFilePath)
+        val testClassInfo = javaFileProcessor.getFullyQualifiedName(targetTestClassFilePath)
 
-        if (context.fullyQualifiedTargetTestClassName.isNullOrBlank()) {
+        if (testClassInfo == null) {
             showError("Cannot get fully qualified name for target test class")
             throw IllegalStateException("Cannot get fully qualified name for target test class")
         }
+
+        context.fullyQualifiedTargetTestClassName = testClassInfo.fullyQualifiedName
     }
 
     private fun collectJavaInfo(testVirtualFile: VirtualFile) {
@@ -77,32 +80,6 @@ class PrepareEnvironmentCommand(project: Project, context: PitestContext) : Pite
         }
     }
 
-    private fun collectTargetClassThatWeTest() {
-        // The user input dialog and file operations don't need to be in ReadAction
-        val targetClass = showInputDialog("Please enter the name of the class that you want to test", "Enter target class")
-        if (targetClass.isNullOrBlank()) {
-            return
-        }
-        val targetClassInfo = FileUtils.findTargetClassFile(context.sourceRoots, targetClass)
-       if (targetClassInfo == null) {
-           showError("Cannot find target class file")
-           throw IllegalStateException("Cannot find target class file")
-       }
-        context.fullyQualifiedTargetClassName = javaFileProcessor.getFullyQualifiedName(targetClassInfo.file.toString())
-        if (context.fullyQualifiedTargetClassName.isNullOrBlank()) {
-            showError("Cannot get fully qualified name for target class")
-            throw IllegalStateException("Cannot get fully qualified name for target class")
-        }
-        context.targetClassSourceRoot = targetClassInfo.sourceRoot.toString()
-    }
-    private fun prepareReportDirectory(){
-        // prepare the report directory
-        ApplicationManager.getApplication().runReadAction {
-            context.reportDirectory = Paths.get(project.basePath!!, "build", "reports", "pitest").toString()
-            File(context.reportDirectory!!).mkdirs()
-        }
-    }
-
     private fun collectResourceDirectories(){
         val resourceDirectories = ReadAction.compute<List<String>, Throwable> {
             GradleUtils.getResourceDirectories(project)
@@ -110,31 +87,68 @@ class PrepareEnvironmentCommand(project: Project, context: PitestContext) : Pite
         context.resourceDirectories = resourceDirectories
     }
 
-    private fun collectClassPathFileForPitest(){
-        if (context.resourceDirectories == null) {
-            collectResourceDirectories()
+    private fun collectTargetClassThatWeTest(sourceRoots:List<Path>) {
+        // The user input dialog and file operations don't need to be in ReadAction
+        val targetClass = showInputDialog("Please enter the name of the class that you want to test", "Enter target class")
+        if (targetClass.isNullOrBlank()) {
+            return
         }
+        val targetClassInfo = FileUtils.findTargetClassFile(sourceRoots, targetClass)
+        if (targetClassInfo == null) {
+            showError("Cannot find target class file")
+            throw IllegalStateException("Cannot find target class file")
+        }
+        val classInfo = javaFileProcessor.getFullyQualifiedName(targetClassInfo.file.toString())
+
+        if (classInfo == null) {
+            showError("Cannot get fully qualified name for target class")
+            throw IllegalStateException("Cannot get fully qualified name for target class")
+        }
+        context.targetClassFullyQualifiedName = classInfo.fullyQualifiedName
+        context.targetClassPackageName = classInfo.packageName
+        context.targetClassSourceRoot = targetClassInfo.sourceRoot.toString()
+    }
+    private fun prepareReportDirectory(testVirtualFile: VirtualFile){
+        // prepare the report directory
+        val parentModulePath = ReadAction.compute<String, Throwable> {
+
+            val projectModule = ProjectRootManager.getInstance(project).fileIndex.getModuleForFile(testVirtualFile)
+            if (projectModule == null) {
+                showError("Cannot find module for test file")
+                throw IllegalStateException("Cannot find module for test file")
+            }
+
+            GradleUtils.getUpperModulePath(project, projectModule)
+        }
+
+        context.reportDirectory = Paths.get(parentModulePath, "build", "reports", "pitest").toString()
+        File(context.reportDirectory!!).mkdirs()
+
+    }
+
+
+
+    private fun collectClassPathFileForPitest(reportDirectory:String, targetPackageName:String, resourceDirectories: List<String>?){
         val classPathFileContent = ReadAction.compute<String, Throwable> {
             val classpath = GradleUtils.getCompilationOutputPaths(project)
             val testDependencies = GradleUtils.getTestRunDependencies(project)
             val allDependencies = ArrayList<String>()
             allDependencies.addAll(classpath)
-            if (context.resourceDirectories != null) {
-                allDependencies.addAll(context.resourceDirectories!!)
+            if (resourceDirectories != null) {
+                allDependencies.addAll(resourceDirectories)
             }
             allDependencies.addAll(testDependencies)
-            val classpathFile = Paths.get(project.basePath!!, "build", "reports", "pitest", "classpath.txt").toString()
-            context.classpathFile = classpathFile
             allDependencies.joinToString("\n")
         }
         showOutput("Classpath file content: $classPathFileContent", "Classpath file content")
+        context.classpathFileDirectory  = Paths.get(reportDirectory, targetPackageName).toString()
+        File(context.classpathFileDirectory).mkdirs()
+        context.classpathFile = Paths.get(context.classpathFileDirectory, "classpath.txt").toString()
         File(context.classpathFile!!).writeText(classPathFileContent)
     }
 
-    private fun setupPitestLibDependencies(){
-        if (context.resourceDirectories == null) {
-            collectResourceDirectories()
-        }
+    private fun setupPitestLibDependencies(resourceDirectories: List<String>) {
+
         val pluginLibDir = ReadAction.compute<String, Throwable> {
             PathManager.getPluginsPath() + "/pitest-intellij/lib"
         }
@@ -149,7 +163,7 @@ class PrepareEnvironmentCommand(project: Project, context: PitestContext) : Pite
                 }
             }
         }
-        dependencies.addAll(context.resourceDirectories!!)
+        dependencies.addAll(resourceDirectories)
         if (dependencies.isEmpty()) {
             Messages.showErrorDialog("Cannot find pitest dependencies", "Error")
             throw IllegalStateException("Cannot find pitest dependencies")

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/PrepareEnvironmentCommand.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/PrepareEnvironmentCommand.kt
@@ -132,17 +132,24 @@ class PrepareEnvironmentCommand(project: Project, context: PitestContext) : Pite
     }
 
     private fun setupPitestLibDependencies(){
+        if (context.resourceDirectories == null) {
+            collectResourceDirectories()
+        }
         val pluginLibDir = ReadAction.compute<String, Throwable> {
             PathManager.getPluginsPath() + "/pitest-intellij/lib"
         }
         val dependencies = mutableListOf<String>()
         for (file in File(pluginLibDir).listFiles()!!) {
+            if (file.name.startsWith("pitest-intellij-")) {
+                continue
+            }
             if (file.name.endsWith(".jar")) {
                 if (file.name.startsWith("pitest") || file.name.startsWith("commons")) {
                     dependencies.add(file.absolutePath)
                 }
             }
         }
+        dependencies.addAll(context.resourceDirectories!!)
         if (dependencies.isEmpty()) {
             Messages.showErrorDialog("Cannot find pitest dependencies", "Error")
             throw IllegalStateException("Cannot find pitest dependencies")

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/RunPitestCommand.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/commands/RunPitestCommand.kt
@@ -15,7 +15,7 @@ class RunPitestCommand (project: Project, context: PitestContext) : PitestComman
         }
 
         thisLogger().info("Run pitest with command: ${command.joinToString(" ")}")
-        File(Paths.get(project.basePath!!, "build", "reports", "pitest", "command.txt").toString()).writeText(command.joinToString(" "))
+        File(Paths.get(context.classpathFileDirectory!!, "command.txt").toString()).writeText(command.joinToString(" "))
 
         context.processResult = ProcessExecutor.executeProcess(command)
     }

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/util/FileUtils.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/util/FileUtils.kt
@@ -21,9 +21,15 @@ object FileUtils {
             return null
         }
 
-        val targetFileName = "$targetClass.java"
+        // Determine if the targetClass is a fully qualified name
+        val targetFileName = if (targetClass.contains('.')) {
+            // Convert fully qualified class name to path
+            targetClass.replace('.', File.separatorChar) + ".java"
+        } else {
+            "$targetClass.java"
+        }
         for (file in Files.walk(directory).filter { path -> Files.isRegularFile(path) }.toList()) {
-            if (file.fileName.toString() == targetFileName) {
+            if (file.toString().endsWith(targetFileName)) {
                 val directoryPath = file.parent
                 val indexToSrcMainJava = directoryPath.toString().indexOf("src${File.separator}main${File.separator}java")
                 val sourceRootPath = directoryPath.toString().substring(0, indexToSrcMainJava)

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/util/GradleUtils.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/util/GradleUtils.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.roots.CompilerModuleExtension
 import com.intellij.openapi.roots.LibraryOrderEntry
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VfsUtil
 import org.jetbrains.plugins.gradle.settings.GradleSettings
 import org.jetbrains.plugins.gradle.util.GradleUtil
@@ -42,7 +43,7 @@ object GradleUtils {
             // Get all dependencies, including libraries
             for (orderEntry in moduleRootManager.orderEntries) {
                 if (orderEntry is LibraryOrderEntry) {
-                    for (file in orderEntry.getFiles(OrderRootType.CLASSES)) {
+                    for (file in orderEntry.getRootFiles(OrderRootType.CLASSES)) {
                         dependencies.add(file.path.removeSuffix("!/"))
                     }
                 } else {
@@ -50,7 +51,7 @@ object GradleUtils {
                     val moduleDependencyRootManager = ModuleRootManager.getInstance(moduleDependency)
                     for (moduleDependencyOrderEntry in moduleDependencyRootManager.orderEntries) {
                         if (moduleDependencyOrderEntry is LibraryOrderEntry) {
-                            for (file in moduleDependencyOrderEntry.getFiles(OrderRootType.CLASSES)) {
+                            for (file in moduleDependencyOrderEntry.getRootFiles(OrderRootType.CLASSES)) {
                                 dependencies.add(file.path.removeSuffix("!/"))
                             }
                         }
@@ -60,5 +61,18 @@ object GradleUtils {
         }
 
         return dependencies.toList()
+    }
+
+    fun getResourceDirectories(project: Project): List<String> {
+        val testResourceDirectories: MutableList<String> = ArrayList()
+        val projectRootManager = ProjectRootManager.getInstance(project)
+        val vFiles = projectRootManager.contentSourceRoots
+        for (vFile in vFiles) {
+            if (vFile.path.endsWith("resources")) {
+                testResourceDirectories.add(vFile.path)
+            }
+        }
+
+        return testResourceDirectories
     }
 }

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/util/GradleUtils.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/util/GradleUtils.kt
@@ -34,6 +34,22 @@ object GradleUtils {
         return outputPaths
     }
 
+    // find the direct parent module's base directory of the child module in the project
+    fun getUpperModulePath(project:Project, childModule:Module):String{
+        var candidateModuleName = ""
+        var candidateModule: Module? = null
+        for (module in project.modules) {
+            val moduleName = module.name
+            if (childModule.name.contains(moduleName) && childModule.name != moduleName) {
+                if (moduleName.length > candidateModuleName.length){
+                    candidateModuleName = moduleName
+                    candidateModule = module
+                }
+            }
+        }
+        return candidateModule?.rootManager?.contentRoots?.get(0)?.path ?: ""
+    }
+
     fun getTestRunDependencies(project: Project): List<String> {
         val dependencies: MutableSet<String> = mutableSetOf()
 

--- a/src/main/kotlin/com/github/jaksonlin/pitestintellij/util/JavaFileProcessor.kt
+++ b/src/main/kotlin/com/github/jaksonlin/pitestintellij/util/JavaFileProcessor.kt
@@ -4,10 +4,12 @@ import com.github.javaparser.JavaParser
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
 import java.io.File
+import kotlin.reflect.jvm.internal.impl.renderer.ClassifierNamePolicy.FULLY_QUALIFIED
 
+data class ClassFileInfo(val fullyQualifiedName: String, val className: String, val packageName: String)
 class JavaFileProcessor {
     // Read the Java File and get the main class's fully qualified name
-    fun getFullyQualifiedName(file: String): String? {
+    fun getFullyQualifiedName(file: String): ClassFileInfo? {
         val content = File(file).readText()
         val parser = JavaParser()
         val compilationUnit: CompilationUnit = parser.parse(content).result.get()
@@ -15,8 +17,15 @@ class JavaFileProcessor {
         // Find the main class in the compilation unit
         val classDeclaration = compilationUnit.findFirst(ClassOrInterfaceDeclaration::class.java).orElse(null)
         return classDeclaration?.let {
-            val packageName = compilationUnit.packageDeclaration.map { it.nameAsString }.orElse("")
-            if (packageName.isNotEmpty()) "$packageName.${it.nameAsString}" else it.nameAsString
+            val packageName = compilationUnit.packageDeclaration.get().nameAsString
+            val className = it.nameAsString
+            val fullyQualifiedName = if (packageName.isEmpty()) {
+                className
+            } else {
+                "$packageName.$className"
+            }
+            ClassFileInfo(fullyQualifiedName, className, packageName)
         }
     }
+
 }


### PR DESCRIPTION
1. allow user to put jar/class file in resource directory, as long as they are marked as resource directory, add them in the startup command for pitest, and also the classpath file.
2. both fully qualified name or class name supported
3. report location is not correctly place near to the source code's build output directory